### PR TITLE
Payment validation

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,4 +1,3 @@
-
 class PaymentsController < ApplicationController
   def index
     @payments = Payment.where(user: current_user)
@@ -9,49 +8,62 @@ class PaymentsController < ApplicationController
     @orders = Order.where(payment: @payment)
   end
 
-
-  #button to pay => post request
-    def create
-    #create new payment instance
-    # @payment = Payment.new
-    @payment = Payment.new(payment_params)
-    @payment.user = current_user
-    # @payment.status = "incomplete"
-    @payment.save #embed validation in payment model
-
-    #assign payment instance to orders
-      # @orders = Order.where(user: current_user && payment == null)
-      # @orders.each do |order|
-      # end
-
-    #validate basket can be processed
-    if @payment.save
-      @payment.status = "Processing" #take status from payment gateway
-      @payment.save
-      #results in "failed" or "success"
-
-      #need to link payment to orders (but cannot get order object)
-      @orders = Order.where(user: current_user, completed: false)
-      @orders.each do |order|
-        order.payment = @payment
-        order.completed = true
-        order.save
+  # Validate all orders, if any one fail, return to cart with error message
+  # initiate a payment instance
+  def create
+    @orders = Order.where(user: current_user, completed: false)
+    deleted_listings = @orders.reject { |order| listing_exist?(order) }
+    insufficient_quantity = @orders.reject { |order| order_quantities_valid?(order) }
+    # raise
+    if deleted_listings.empty? && insufficient_quantity.empty?
+      @payment = Payment.new(payment_params)
+      @payment.user = current_user
+      @payment.status = "Completed"
+      if @payment.save
+        update_orders_qty(@orders)
+        redirect_to payment_path(@payment)
+      else
+        redirect_to orders_path, alert: "Failed to confirm transaction"
       end
-
-
-      redirect_to payment_path(@payment)
     else
-      render "orders/index"
+      msg = build_alert(deleted_listings, insufficient_quantity)
+      redirect_to orders_path, alert: msg
     end
   end
+
   private
 
-    def payment_params
-      params.require(:payment).permit(:user, :total_price, :status)
-    end
+  def payment_params
+    params.require(:payment).permit(:total_price, :status)
+  end
 
-    def validate_payment_success
-      true
-    end
+  def listing_exist?(order)
+    !order.listing.nil?
+  end
 
+  def order_quantities_valid?(order)
+    order.quantity_ordered <= order.listing.quantity_available
+  end
+
+  def update_orders_qty(orders)
+    orders.each do |order|
+      order.payment = @payment
+      order.completed = true
+      order.save
+      order.listing.quantity_available -= order.quantity_ordered
+      order.listing.save
+    end
+  end
+
+  def build_alert(deleted_listings, insufficient_quantity)
+    if deleted_listings.any?
+      deleted = deleted_listings.map { |order| order.listing.name }
+      msg1 = "#{deleted.join(', ')} has been removed from the seller; "
+    end
+    if insufficient_quantity.any?
+      insufficient = insufficient_quantity.map { |order| order.listing.name }
+      msg2 = "#{insufficient.join(', ')} have insufficient stock; "
+    end
+    "#{msg1}#{msg2}Please edit your cart before checking out again."
+  end
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,6 +1,6 @@
 class Listing < ApplicationRecord
   belongs_to :user
-  has_many :orders
+  has_many :orders # cannot use dependent :destroy, as sold orders cannot be unsold even though the current listing is deleted
   has_one_attached :photo
 
   validates :name, presence: true

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,7 +1,7 @@
 class Payment < ApplicationRecord
   # relationship
   belongs_to :user
-  has_many :orders
+  has_many :orders, dependent: :destroy
 
   # validation
   validates :total_price, presence: true, numericality: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   # relationship
-  has_many :payments
-  has_many :orders
+  has_many :payments, dependent: :destroy
+  has_many :orders # Orders cannot be destroyed as seller needs the order info in their payments records
   has_many :listings, dependent: :destroy
 
   # validation

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,7 +46,7 @@ puts "jill seeded"
 ################################################################################
 
 puts
-puts "Seeding 11 listings"
+puts "Seeding 10 listings"
 flour = Listing.create!(
     name: 'Flour',
     description: 'A bag of self-raising flour',


### PR DESCRIPTION
**Which issue does this reference or resolve?**
- #35 

**What's been done?** 

**Payments controller:**
- Added to user model `has_many :payments, dependent: :destroy` 
- Removed `:user` from `payment_params` as it does not exist there
- When user makes payment successfully, Order will be updated with `completed: true` and Listing will have `listing_price_pq` updated. 
- In user.rb User model, added `has_many :payments, dependent: :destroy`. This is not relevant to our user stories but will be helpful when testing around in development, I think it makes sense.
- In payment.rb Payment model, updated `has_many :orders, dependent: :destroy`. Allows us to delete payments from the console for testing purpose. Also allow us to let user delete payments where the buyer decides not to follow through with the purchase later on.

Before checkout:
![image](https://user-images.githubusercontent.com/59186927/84220194-d29dd780-ab04-11ea-880d-0ac53e956ef6.png)

After clicking checkout, someone else have just bought the last Bell Pepper, so new quantity is 0:
![image](https://user-images.githubusercontent.com/59186927/84220233-e5b0a780-ab04-11ea-96c4-4cdc40509dc9.png)

---

**Other issues not resolved**

1. Orders#index view:
When listing quantity_available is no longer enough, order is not automatically deleted. Do we want to delete or let the user delete like this in the cart page:
￼
This is the current view.

2. Pages#home controller/view:
When quantity_available = 0, listing is still shown. 

3. Listings#show:
When user submit quantity form with empty field and click on ‘Add to Cart’, will lead to error. Need to disable submitting empty field.

**Additional notes** 
- Please help to see if there is any logical flaw that need to be fixed and create a new issue if any.
