### PR TITLE
Allowed soft delete listings and enforced authorization

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,4 +1,5 @@
 class OrdersController < ApplicationController
+  before_action :check_user?, only: [:update, :destroy]
 
   def index
     orders = Order.where(user: current_user, completed: false)
@@ -35,7 +36,6 @@ class OrdersController < ApplicationController
   end
 
   def update
-    @order = Order.find(params[:id])
     @order.quantity_ordered = params[:order][:quantity_ordered]
     if validate_quantity?(@order)
       if @order.save
@@ -49,7 +49,7 @@ class OrdersController < ApplicationController
   end
 
   def destroy
-    Order.find(params[:id]).destroy
+    @order.destroy
     redirect_to orders_path
   end
 
@@ -69,5 +69,13 @@ class OrdersController < ApplicationController
   # create
   def existing_orders_for_listing
     Order.where(user: current_user, listing: @listing, completed: false)
+  end
+
+  #update, #destroy
+  def check_user?
+    @order = Order.find(params[:id])
+    if @order.user != current_user
+      redirect_to orders_path, alert: "You are not authorized."
+    end
   end
 end

--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -1,14 +1,12 @@
-<div class="container">
-  <div class="row m-0 p-0">
-    <% if current_user == @listing.user %>
-      <div class="col">
-        <%= link_to "Delete", listing_path(@listing), method: :delete  %>
-      </div>
-      <div class="col text-right">
-        <%= link_to "Edit", edit_listing_path(@listing), class: "btn btn-primary" %>
-      </div>
-    <% end  %>
+<div class="d-flex flex-row-reverse my-3">
+  <% if current_user == @listing.user %>
+  <div class="mx-1">
+    <%= link_to "Delete", listing_path(@listing), method: :delete, class: "btn btn-danger"%>
   </div>
+  <div class="mx-1">
+    <%= link_to "Edit", edit_listing_path(@listing), class: "btn btn-primary" %>
+  </div>
+  <% end  %>
 </div>
 
 <div class="p-3">

--- a/db/migrate/20200611125300_add_delete_status_to_listings.rb
+++ b/db/migrate/20200611125300_add_delete_status_to_listings.rb
@@ -1,0 +1,5 @@
+class AddDeleteStatusToListings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :listings, :delete_status, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_09_090051) do
+ActiveRecord::Schema.define(version: 2020_06_11_125300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_06_09_090051) do
     t.float "listing_price_pq"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "delete_status", default: false
     t.index ["user_id"], name: "index_listings_on_user_id"
   end
 


### PR DESCRIPTION
**Which issue does this reference or resolve?**
#56 

**What's been done?** 
- Added column `delete_status` with default value of false in listings table
- listings#destroy action/method do not destroy the instance of listing but just set listing.delete_status = true
- listings#index action/method only takes @listings where deleted_status is false
- listings#show view should not be shown if listing.delete_status = true, instead redirect to listings#index path
- listings#edit and listings#update should only be accessible to owners of the listing, defined in the listings controller
- added same check_user? in orders#destroy, #update
- refactored check_user in both listings controller and orders controller

**Additional notes** 
Do run `rails db:migrate` after pulling from master when merged.